### PR TITLE
Small project option changes

### DIFF
--- a/CoolBeans.Rproj
+++ b/CoolBeans.Rproj
@@ -1,7 +1,7 @@
 Version: 1.0
 
-RestoreWorkspace: Default
-SaveWorkspace: Default
+RestoreWorkspace: No
+SaveWorkspace: No
 AlwaysSaveHistory: Default
 
 EnableCodeIndexing: Yes

--- a/CoolBeans.Rproj
+++ b/CoolBeans.Rproj
@@ -18,3 +18,7 @@ StripTrailingWhitespace: Yes
 BuildType: Package
 PackageUseDevtools: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source
+
+MarkdownWrap: Column
+MarkdownWrapAtColumn: 72
+MarkdownCanonical: Yes


### PR DESCRIPTION
Just adding some project options, like making it so Markdown gets automatically reformatted into standard markdown. This makes it easier to collaborate and read markdown, and can be used to find issues with markdown.