### PR TITLE
Small change to Rproj to add documentation building with Ctrl-Shift-B

### DIFF
--- a/CoolBeans.Rproj
+++ b/CoolBeans.Rproj
@@ -18,6 +18,7 @@ StripTrailingWhitespace: Yes
 BuildType: Package
 PackageUseDevtools: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source
+PackageRoxygenize: rd,collate,namespace
 
 MarkdownWrap: Column
 MarkdownWrapAtColumn: 72


### PR DESCRIPTION
A very small change to allow you to build documentation by running `Ctrl-Shift-D` (keybinding for `devtools::document()`). See https://r-pkgs.org/man.html#sec-man-workflow for the workflow.